### PR TITLE
Add generic argument of TDescribed for ActionDescribedAsset 

### DIFF
--- a/Assets/UGF.Module.Actions.Runtime.Tests/TestActionAsset.cs
+++ b/Assets/UGF.Module.Actions.Runtime.Tests/TestActionAsset.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UGF.Module.Actions.Runtime.Tests
 {
     [CreateAssetMenu(menuName = "Tests/TestActionDescriptionAsset")]
-    public class TestActionAsset : ActionDescribedAsset<TestActionDescription>
+    public class TestActionAsset : ActionDescribedAsset<TestAction, TestActionDescription>
     {
         [SerializeField] private int m_value;
 
@@ -15,7 +15,7 @@ namespace UGF.Module.Actions.Runtime.Tests
             return new TestActionDescription(m_value);
         }
 
-        protected override IAction OnBuild(TestActionDescription description)
+        protected override TestAction OnBuild(TestActionDescription description)
         {
             return new TestAction(description);
         }

--- a/Assets/UGF.Module.Actions.Runtime.Tests/TestActionRotateTargetAsset.cs
+++ b/Assets/UGF.Module.Actions.Runtime.Tests/TestActionRotateTargetAsset.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace UGF.Module.Actions.Runtime.Tests
 {
     [CreateAssetMenu(menuName = "Tests/TestActionRotateTargetDescriptionAsset")]
-    public class TestActionRotateTargetAsset : ActionDescribedAsset<TestActionRotateTargetDescription>
+    public class TestActionRotateTargetAsset : ActionDescribedAsset<TestActionRotateTarget, TestActionRotateTargetDescription>
     {
         [SerializeField] private float m_speed = 1F;
 
@@ -16,7 +16,7 @@ namespace UGF.Module.Actions.Runtime.Tests
             return new TestActionRotateTargetDescription(m_speed);
         }
 
-        protected override IAction OnBuild(TestActionRotateTargetDescription description)
+        protected override TestActionRotateTarget OnBuild(TestActionRotateTargetDescription description)
         {
             return new TestActionRotateTarget(description);
         }

--- a/Packages/UGF.Module.Actions/Runtime/ActionDescribedAsset`2.cs
+++ b/Packages/UGF.Module.Actions/Runtime/ActionDescribedAsset`2.cs
@@ -5,8 +5,9 @@ using UGF.Description.Runtime;
 
 namespace UGF.Module.Actions.Runtime
 {
-    [Obsolete("ActionDescribedAsset`1 has been deprecated. Use ActionDescribedAsset`2 instead.")]
-    public abstract class ActionDescribedAsset<TDescription> : ActionAssetBase, IDescribedBuilder, IDescriptionBuilder where TDescription : class, IActionDescription
+    public abstract class ActionDescribedAsset<TDescribed, TDescription> : ActionAssetBase, IDescribedBuilder, IDescriptionBuilder
+        where TDescribed : class, IActionDescribed
+        where TDescription : class, IActionDescription
     {
         protected override IAction OnBuild()
         {
@@ -18,7 +19,7 @@ namespace UGF.Module.Actions.Runtime
         }
 
         protected abstract TDescription OnBuildDescription();
-        protected abstract IAction OnBuild(TDescription description);
+        protected abstract TDescribed OnBuild(TDescription description);
 
         T IBuilder<IDescribed>.Build<T>()
         {
@@ -27,7 +28,7 @@ namespace UGF.Module.Actions.Runtime
 
         IDescribed IBuilder<IDescribed>.Build()
         {
-            return (IDescribed)OnBuild();
+            return (IActionDescribed)OnBuild();
         }
 
         T IBuilder<IDescription>.Build<T>()

--- a/Packages/UGF.Module.Actions/Runtime/ActionDescribedAsset`2.cs.meta
+++ b/Packages/UGF.Module.Actions/Runtime/ActionDescribedAsset`2.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 358be410fb73406f88cc331639f26c54
+timeCreated: 1610281285


### PR DESCRIPTION
- Add `ActionDescribedAsset` with `TDescribed` and `TDescription` generic arguments.
- Change `ActionDescribedAsset` with one generic argument to be deprecated.