### PR TITLE
Update dependencies

### DIFF
--- a/Assets/UGF.Module.Actions.Runtime.Tests/TestActionModule.cs
+++ b/Assets/UGF.Module.Actions.Runtime.Tests/TestActionModule.cs
@@ -4,6 +4,7 @@ using UGF.Application.Runtime;
 using UGF.Module.Update.Runtime;
 using UGF.Update.Runtime;
 using UnityEngine;
+using UnityEngine.LowLevel;
 using UnityEngine.TestTools;
 
 namespace UGF.Module.Actions.Runtime.Tests
@@ -24,7 +25,7 @@ namespace UGF.Module.Actions.Runtime.Tests
 
             application.Uninitialize();
 
-            Debug.Log(application.GetModule<IUpdateModule>().Provider.UpdateLoop.GetPlayerLoop().Print());
+            Debug.Log(PlayerLoop.GetCurrentPlayerLoop().Print());
         }
 
         [UnityTest]
@@ -45,7 +46,7 @@ namespace UGF.Module.Actions.Runtime.Tests
 
             application.Uninitialize();
 
-            Debug.Log(application.GetModule<IUpdateModule>().Provider.UpdateLoop.GetPlayerLoop().Print());
+            Debug.Log(PlayerLoop.GetCurrentPlayerLoop().Print());
         }
 
         [UnityTest]

--- a/Packages/UGF.Module.Actions/Runtime/ActionModuleAsset.cs
+++ b/Packages/UGF.Module.Actions/Runtime/ActionModuleAsset.cs
@@ -16,7 +16,10 @@ namespace UGF.Module.Actions.Runtime
 
         protected override IApplicationModuleDescription OnBuildDescription()
         {
-            var description = new ActionModuleDescription(typeof(IActionModule));
+            var description = new ActionModuleDescription
+            {
+                RegisterType = typeof(IActionModule)
+            };
 
             for (int i = 0; i < m_groups.Count; i++)
             {

--- a/Packages/UGF.Module.Actions/Runtime/ActionModuleDescription.Deprecated.cs
+++ b/Packages/UGF.Module.Actions/Runtime/ActionModuleDescription.Deprecated.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace UGF.Module.Actions.Runtime
+{
+    public partial class ActionModuleDescription
+    {
+        [Obsolete("ActionModuleDescription constructor with 'registerType' argument has been deprecated. Use default constructor and properties initialization instead.")]
+        public ActionModuleDescription(Type registerType) : base(registerType)
+        {
+        }
+    }
+}

--- a/Packages/UGF.Module.Actions/Runtime/ActionModuleDescription.Deprecated.cs.meta
+++ b/Packages/UGF.Module.Actions/Runtime/ActionModuleDescription.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dba479f5a1bd4364a43d1c96711a9202
+timeCreated: 1610803853

--- a/Packages/UGF.Module.Actions/Runtime/ActionModuleDescription.cs
+++ b/Packages/UGF.Module.Actions/Runtime/ActionModuleDescription.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UGF.Actions.Runtime;
 using UGF.Application.Runtime;
 
 namespace UGF.Module.Actions.Runtime
 {
-    public class ActionModuleDescription : ApplicationModuleDescription, IActionModuleDescription
+    public partial class ActionModuleDescription : ApplicationModuleDescription, IActionModuleDescription
     {
         public Dictionary<string, IActionUpdateGroupBuilder> Groups { get; } = new Dictionary<string, IActionUpdateGroupBuilder>();
         public Dictionary<string, IActionSystemBuilder> Systems { get; } = new Dictionary<string, IActionSystemBuilder>();
@@ -13,7 +12,7 @@ namespace UGF.Module.Actions.Runtime
         IReadOnlyDictionary<string, IActionUpdateGroupBuilder> IActionModuleDescription.Groups { get { return Groups; } }
         IReadOnlyDictionary<string, IActionSystemBuilder> IActionModuleDescription.Systems { get { return Systems; } }
 
-        public ActionModuleDescription(Type registerType) : base(registerType)
+        public ActionModuleDescription()
         {
         }
     }

--- a/Packages/UGF.Module.Actions/package.json
+++ b/Packages/UGF.Module.Actions/package.json
@@ -22,7 +22,7 @@
     "registry": "https://api.bintray.com/content/unity-game-framework/public"
   },
   "dependencies": {
-    "com.ugf.actions": "1.0.1",
+    "com.ugf.actions": "2.0.0",
     "com.ugf.module.update": "2.0.0"
   }
 }

--- a/Packages/UGF.Module.Actions/package.json
+++ b/Packages/UGF.Module.Actions/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "com.ugf.actions": "2.0.0",
-    "com.ugf.module.update": "2.0.0"
+    "com.ugf.module.update": "2.1.0"
   }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ugf.actions": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -82,7 +82,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.actions": "1.0.1",
+        "com.ugf.actions": "2.0.0",
         "com.ugf.module.update": "2.0.0"
       }
     },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,13 +10,14 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.application": {
-      "version": "6.0.0",
+      "version": "7.1.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
-        "com.ugf.customsettings": "3.4.0"
+        "com.ugf.customsettings": "3.4.0",
+        "com.ugf.logs": "5.1.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
@@ -38,7 +39,7 @@
     },
     "com.ugf.defines": {
       "version": "2.1.0",
-      "depth": 3,
+      "depth": 4,
       "source": "registry",
       "dependencies": {
         "com.ugf.customsettings": "3.4.0"
@@ -69,8 +70,8 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.logs": {
-      "version": "4.1.0",
-      "depth": 2,
+      "version": "5.1.0",
+      "depth": 3,
       "source": "registry",
       "dependencies": {
         "com.ugf.defines": "2.1.0"
@@ -83,17 +84,16 @@
       "source": "embedded",
       "dependencies": {
         "com.ugf.actions": "2.0.0",
-        "com.ugf.module.update": "2.0.0"
+        "com.ugf.module.update": "2.1.0"
       }
     },
     "com.ugf.module.update": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.application": "6.0.0",
-        "com.ugf.update": "5.2.1",
-        "com.ugf.logs": "4.1.0"
+        "com.ugf.application": "7.1.0",
+        "com.ugf.update": "5.2.1"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },


### PR DESCRIPTION
- Update dependencies: `com.ugf.actions` to  `2.0.0` version and `com.ugf.module.update` to `2.1.0` version.
- Deprecate `ActionModuleDescription` constructor with `registerType` argument, use properties initialization instead. 